### PR TITLE
Restrict Access to Route needs Authorization

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,7 +17,7 @@ import AuthenticationPage, {
   action as authFormAction,
 } from "./pages/Authentication";
 import { action as logoutAction } from "./pages/Logout";
-import { tokenLoader } from "./util/auth";
+import { tokenLoader, checkAuthLoader } from "./util/auth";
 
 const router = createBrowserRouter([
   {
@@ -56,6 +56,7 @@ const router = createBrowserRouter([
                 path: "edit",
                 element: <EditEventPage />,
                 action: manipulateEventAction,
+                loader: checkAuthLoader,
               },
             ],
           },
@@ -63,6 +64,7 @@ const router = createBrowserRouter([
             path: "new",
             element: <NewEventPage />,
             action: manipulateEventAction,
+            loader: checkAuthLoader,
           },
         ],
       },

--- a/frontend/src/util/auth.js
+++ b/frontend/src/util/auth.js
@@ -1,3 +1,5 @@
+import { redirect } from "react-router-dom";
+
 export const getAuthToken = () => {
   const token = localStorage.getItem("token");
   return token;
@@ -5,4 +7,13 @@ export const getAuthToken = () => {
 
 export const tokenLoader = () => {
   return getAuthToken();
+};
+
+export const checkAuthLoader = () => {
+  const token = localStorage.getItem("token");
+
+  if (!token) {
+    return redirect("/");
+  }
+  return null;
 };


### PR DESCRIPTION
- 어떤 Route에 접근 권한이 있는 유저만 접근할 수 있도록 해준다.
- Route에 접근하는 버튼을 없앤다 해도, 사용자가 만약 URL을 추측하여 알게 된다면 접근을 막을 수 없다.
- 따라서 loader를 사용하여 해당 사용자의 localStorage에 token이 있는지 없는지를 확인한다.
- 있으면 return null, 없으면 return redirect를 통해 원하는 흐름을 유도한다.