### PR TITLE
set token duration and expiration

### DIFF
--- a/frontend/src/components/EventItem.js
+++ b/frontend/src/components/EventItem.js
@@ -3,7 +3,7 @@ import { Link, useSubmit, useRouteLoaderData } from "react-router-dom";
 import classes from "./EventItem.module.css";
 
 const EventItem = ({ event }) => {
-  const token = useRouteLoaderData();
+  const token = useRouteLoaderData("root");
   const submit = useSubmit();
 
   const startDeleteHandler = () => {

--- a/frontend/src/pages/Authentication.js
+++ b/frontend/src/pages/Authentication.js
@@ -42,5 +42,9 @@ export const action = async ({ request }) => {
 
   localStorage.setItem("token", token);
 
+  const expiration = new Date();
+  expiration.setHours(expiration.getHours() + 1);
+  localStorage.setItem("expiration", expiration.toISOString());
+
   return redirect("/");
 };

--- a/frontend/src/pages/Logout.js
+++ b/frontend/src/pages/Logout.js
@@ -2,5 +2,6 @@ import { redirect } from "react-router-dom";
 
 export const action = () => {
   localStorage.removeItem("token");
+  localStorage.removeItem("expiration");
   return redirect("/");
 };

--- a/frontend/src/pages/Root.js
+++ b/frontend/src/pages/Root.js
@@ -1,9 +1,30 @@
-import { Outlet, useNavigation } from 'react-router-dom';
+import { useEffect } from "react";
 
-import MainNavigation from '../components/MainNavigation';
+import { Outlet, useLoaderData, useSubmit } from "react-router-dom";
 
-function RootLayout() {
-  // const navigation = useNavigation();
+import MainNavigation from "../components/MainNavigation";
+import { getTokenDuration } from "../util/auth";
+
+const RootLayout = () => {
+  const token = useLoaderData();
+  const submit = useSubmit();
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    if (token === "EXPIRED") {
+      submit(null, { action: "/logout", method: "POST" });
+    }
+
+    const tokenDuration = getTokenDuration();
+    console.log(tokenDuration);
+
+    setTimeout(() => {
+      submit(null, { action: "/logout", method: "POST" });
+    }, tokenDuration);
+  }, [token, submit]);
 
   return (
     <>
@@ -14,6 +35,6 @@ function RootLayout() {
       </main>
     </>
   );
-}
+};
 
 export default RootLayout;

--- a/frontend/src/util/auth.js
+++ b/frontend/src/util/auth.js
@@ -1,7 +1,26 @@
 import { redirect } from "react-router-dom";
 
+export const getTokenDuration = () => {
+  const storedExpirationDate = localStorage.getItem("expiration");
+  const expirationDate = new Date(storedExpirationDate);
+  const now = new Date();
+  const duration = expirationDate.getTime() - now.getTime();
+  return duration;
+};
+
 export const getAuthToken = () => {
   const token = localStorage.getItem("token");
+
+  if (!token) {
+    return null;
+  }
+
+  const tokenDuration = getTokenDuration();
+
+  if (tokenDuration < 0) {
+    return "EXPIRED";
+  }
+
   return token;
 };
 


### PR DESCRIPTION
- auth 라우트에서 발생하는 action은 path를 Root로 redirect시킨다.
- Root 라우터로 이동되면서 loader가 실행되고 RootLayout에서 loader의 결과값을 받는다.
- 이에 따라 loader의 결과값을 의존성으로 가지는 useEffect가 실행되어 토큰의 상태를 체크한다.
- 토큰의 지속시간을 추출하여 logout path로 이어지는 action submit의 실행시간으로 잡아준다.
- 이렇게 함으로써 토큰이 만료되었을 때 자동으로 로그아웃되도록 구현할 수 있다.